### PR TITLE
fix: Gracefully shutdown

### DIFF
--- a/internal/app/input/command/command.go
+++ b/internal/app/input/command/command.go
@@ -2,17 +2,13 @@ package command
 
 import (
 	"context"
-	"github.com/yael-castro/outbox/internal/app/business"
-	"log"
 )
 
-type Command func(context.Context)
+const (
+	successExitCode        = 0
+	fatalExitCode          = 1
+	incorrectUsageExitCode = 2
+)
 
-func Relay(relay business.MessagesRelay, errLogger *log.Logger) Command {
-	return func(ctx context.Context) {
-		err := relay.RelayMessages(ctx)
-		if err != nil {
-			errLogger.Println(err)
-		}
-	}
-}
+// Command alias for "func(context.Context) int"
+type Command = func(context.Context) int

--- a/internal/app/input/command/relay.go
+++ b/internal/app/input/command/relay.go
@@ -1,0 +1,20 @@
+package command
+
+import (
+	"context"
+	"github.com/yael-castro/outbox/internal/app/business"
+	"log"
+)
+
+// Relay builds the command for relay messages
+func Relay(relay business.MessagesRelay, errLogger *log.Logger) Command {
+	return func(ctx context.Context) int {
+		err := relay.RelayMessages(ctx)
+		if err != nil {
+			errLogger.Println(err)
+			return fatalExitCode
+		}
+
+		return successExitCode
+	}
+}


### PR DESCRIPTION
In this commit I have changed the way gracefully shutdown is performed.

In this new approach programs wait for a cancel signal, an error or a successful execution.

Also fix incorrect exit codes returned in some error scenarios. For example: When an http server tries to use a used port.